### PR TITLE
Mark podspec to be using ARC

### DIFF
--- a/BNHtmlPdfKit.podspec
+++ b/BNHtmlPdfKit.podspec
@@ -7,5 +7,6 @@ Pod::Spec.new do |s|
   s.author       = { 'Brent Nycum' => 'brentnycum@gmail.com' }
   s.source       = { :git => 'https://github.com/brentnycum/BNHtmlPdfKit.git', :tag => '0.1.2' }
   s.source_files = 'BNHtmlPdfKit.{h,m}'
+  s.requires_arc = true
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
 end


### PR DESCRIPTION
Before this commit the pod was using ARC, but not declaring it in the pod spec file lead to leaks. 
This is a important pull request, otherwise the classes will be treated as non-ARC, but internally using ARC.
