### PR TITLE
Directly save existing WebView content to PDF and A4 page size fix

### DIFF
--- a/BNHtmlPdfKit.h
+++ b/BNHtmlPdfKit.h
@@ -160,7 +160,7 @@ Saves an webView to PDF data.
 
 @param webView The webView to save as a pdf.
 */
-- (void)saveWebViewAsPdf:(NSString *)html;
+- (void)saveWebViewAsPdf:(UIWebView *)webView;
 
 /**
 Saves webView content to a PDF file.

--- a/BNHtmlPdfKit.h
+++ b/BNHtmlPdfKit.h
@@ -156,6 +156,21 @@ Saves an html string to a PDF file.
 - (void)saveUrlAsPdf:(NSURL *)url toFile:(NSString *)file;
 
 /**
+Saves an webView to PDF data.
+
+@param webView The webView to save as a pdf.
+*/
+- (void)saveWebViewAsPdf:(NSString *)html;
+
+/**
+Saves webView content to a PDF file.
+
+@param webView The webView to save as a pdf file.
+@param file The filename of the pdf file to save.
+*/
+- (void)saveWebViewAsPdf:(UIWebView *)webView toFile:(NSString *)file;
+
+/**
 Determine the preferred paper size for general printing. From Pierre Bernard.
 
 @return paper size (currently: A4 or Letter).

--- a/BNHtmlPdfKit.m
+++ b/BNHtmlPdfKit.m
@@ -127,6 +127,18 @@
 	[self.webView loadRequest:[NSURLRequest requestWithURL:url]];
 }
 
+- (void)saveWebViewAsPdf:(UIWebView *)webView {
+    [self saveWebViewAsPdf:webView toFile:nil];
+}
+
+- (void)saveWebViewAsPdf:(UIWebView *)webView toFile:(NSString *)file {
+	self.outputFile = file;
+
+    webView.delegate = self;
+    
+    self.webView = webView;
+}
+
 #pragma mark - UIWebViewDelegate
 
 - (void)webViewDidFinishLoad:(UIWebView *)webView {

--- a/BNHtmlPdfKit.m
+++ b/BNHtmlPdfKit.m
@@ -211,7 +211,7 @@
 		case BNPageSizeA3:
 			return BNSizeMakeWithPPI(11.69f, 16.54f);
 		case BNPageSizeA4:
-			return BNSizeMakeWithPPI(8.27f, 11.69f);
+			return BNSizeMakeWithPPI(8.26666667, 11.6916667);
 		case BNPageSizeA5:
 			return BNSizeMakeWithPPI(5.83f, 8.27f);
 		case BNPageSizeA6:


### PR DESCRIPTION
This pull request adds the option to directly save the content of an existing WebView directly to PDF. By using this option there is no need to re-download or re-generate the content of an existing WebView when you are already displaying the content to the user. Also this fixed for me the problem that remote images in local generated HTML, where not saved to the PDF.

Secondly this pull request fixes extra blank pages when using A4 page size, by updating the page size to be more precise.

Regards Patrick
